### PR TITLE
fix: remove req from passport jwt strategy

### DIFF
--- a/api/middleware/authentication/passport.js
+++ b/api/middleware/authentication/passport.js
@@ -9,7 +9,7 @@ const { ExtractJwt } = require('passport-jwt');
 passport.use(new JwtStrategy({
     jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken('authorization'),
     secretOrKey   : process.env.JWT_SECRET
-}, async (req, payload, done) => {
+}, async (payload, done) => {
     try {
         // find user
         const user =  await User.findOneById(payload.sub);


### PR DESCRIPTION
without passReqToCallback option, callback parameters should be (payload, done)

[jwt strategy](http://www.passportjs.org/packages/passport-jwt/)